### PR TITLE
Use utf-8 when latin encoding fails

### DIFF
--- a/PyPDF2/utils.py
+++ b/PyPDF2/utils.py
@@ -235,7 +235,10 @@ else:
         if type(s) == bytes:
             return s
         else:
-            r = s.encode('latin-1')
+            try:
+                r = s.encode('latin-1')
+            except:
+                r = s.encode('utf-8')
             if len(s) < 2:
                 bc[s] = r
             return r


### PR DESCRIPTION
This fixes an error (`ordinal not in range(256)`) that occurs while writing output stream, in case `latin-1` is unable to encode certain characters.